### PR TITLE
fix(index): use provided joi to extend

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const Joi = require('joi');
-
-module.exports = {
+module.exports = (joi) => ({
     name: 'number',
-    base: Joi.number(),
+    base: joi.number(),
     language: {
         map: 'must be a number or one of {{enums}}'
     },
@@ -32,7 +30,7 @@ module.exports = {
                 return 'Should map enumerated strings';
             },
             params: {
-                map: Joi.object()
+                map: joi.object()
             },
             setup(params) {
 
@@ -44,4 +42,4 @@ module.exports = {
             }
         }
     ]
-};
+});


### PR DESCRIPTION
See https://github.com/hapijs/joi/blob/master/API.md#examples 
It is considered safer since the versions will match up better.
Also I think you can remove the peerdep now but not 100% sure (I don't have it in my custom rule and works fine :P)