### PR TITLE
Fixes "Cannot read property 'value' of undefined at type.coerce"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
             return value;
         }
 
-        if (options.convert && typeof value === 'string') {
+        if (this._map && options.convert && typeof value === 'string') {
             if (this._map[value] !== undefined) {
                 return this._map[value];
             }


### PR DESCRIPTION
Seems like coerce is applied on all numbers, which leads to an error when using Joi.number() without .map() (and the input is a string)